### PR TITLE
ci: build via Dockerfile in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,43 @@
+---
 language: rust
-rust:
-  - 1.39.0  # minimum supported toolchain
-  - stable
-  - beta
-  - nightly
+os: linux
+services:
+  - docker
 
-matrix:
+jobs:
   allow_failures:
     - rust: nightly
-
-script:
-  - cargo build
-  - cargo test
+  include:
+    - name: "Test with nightly toolchain"
+      arch: amd64
+      rust: nightly
+      script:
+        - cargo test
+    - name: "Test with stable toolchain"
+      arch: amd64
+      rust: stable
+      script:
+        - cargo test
+    - name: "Test with beta toolchain"
+      arch: amd64
+      rust: beta
+      script:
+        - cargo test
+    - name: "Test with minimum supported toolchain"
+      arch: amd64
+      rust: 1.39.0
+      script:
+        - cargo test --release
+    - name: "Lints with pinned toolchain"
+      arch: amd64
+      rust: 1.44.0
+      before_script:
+        - rustup component add clippy
+        - rustup component add rustfmt
+      script:
+        - cargo clippy -- -D warnings
+        - cargo fmt -- --check -l
+    - name: "Build container via Dockerfile"
+      arch: amd64
+      script:
+        - docker build -f dist/fedora-infra/Dockerfile .


### PR DESCRIPTION
This reworks the Travis setup and adds a new job taking care
of building via Dockerfile.