### PR TITLE
scraper: lower connection idle timeout

### DIFF
--- a/dumnati/src/scraper.rs
+++ b/dumnati/src/scraper.rs
@@ -29,6 +29,7 @@ impl Scraper {
         let releases_json = envsubst::substitute(metadata::RELEASES_JSON, &vars)?;
         let stream_json = envsubst::substitute(metadata::STREAM_JSON, &vars)?;
         let hclient = reqwest::ClientBuilder::new()
+            .pool_idle_timeout(Some(Duration::from_secs(10)))
             .timeout(DEFAULT_HTTP_REQ_TIMEOUT)
             .build()?;
 


### PR DESCRIPTION
This lowers the idle timeout on reqwest connection pool so that it
is lower than the S3/Cloudfront idle timeout (20s).
It should help avoiding races with the server closing an idle connection
in the pool, which at the same time has been selected for sending the
next request.

Ref: https://aws.amazon.com/premiumsupport/knowledge-center/s3-socket-connection-timeout-error/