### PR TITLE
fcos-policy-engine: fetch graph from fcos-graph-builder instance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "derive_more"
 version = "0.99.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +716,7 @@ dependencies = [
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_qs 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1627,6 +1642,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "data-encoding 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,6 +2206,7 @@ dependencies = [
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+"checksum data-encoding 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72aa14c04dfae8dd7d8a2b1cb7ca2152618cd01336dbfe704b8dcbf8d41dbd69"
 "checksum derive_more 0.99.9 (registry+https://github.com/rust-lang/crates.io-index)" = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
 "checksum dtoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
@@ -2187,6 +2214,7 @@ dependencies = [
 "checksum enum-as-inner 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4bfcfacb61d231109d1d55202c1f33263319668b168843e02ad4652725ec9c"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum envsubst 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "87bf9e478f69f88f589c11ddc017e4ddfcfd196ee2c9a4249074c83ddf544162"
+"checksum error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
 "checksum failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 "checksum failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 "checksum flate2 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
@@ -2296,6 +2324,7 @@ dependencies = [
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 "checksum serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 "checksum serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)" = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
+"checksum serde_qs 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c6f3acf84e23ab27c01cb5917551765c01c50b2000089db8fa47fe018a3260cf"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"

--- a/fcos-policy-engine/Cargo.toml
+++ b/fcos-policy-engine/Cargo.toml
@@ -23,4 +23,5 @@ reqwest = { version = "^0.10.1", features = ["json"] }
 serde = "^1.0.70"
 serde_derive = "^1.0.70"
 serde_json = "^1.0.22"
+serde_qs = "0.6.1"
 structopt = "^0.3.7"

--- a/fcos-policy-engine/src/main.rs
+++ b/fcos-policy-engine/src/main.rs
@@ -3,11 +3,13 @@ extern crate log;
 #[macro_use]
 extern crate prometheus;
 
+mod utils;
+
 use actix_web::{web, App, HttpResponse};
-use commons::{graph, metrics, policy};
+use commons::{metrics, policy};
 use failure::{Error, Fallible};
 use prometheus::{Histogram, IntCounter, IntGauge};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use structopt::StructOpt;
@@ -83,7 +85,7 @@ pub(crate) struct AppState {
     population: Arc<cbloom::Filter>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GraphQuery {
     basearch: Option<String>,
     stream: Option<String>,
@@ -108,11 +110,9 @@ pub(crate) async fn pe_serve_graph(
     let wariness = compute_wariness(&query);
     ROLLOUT_WARINESS.observe(wariness);
 
-    // TODO (zonggen): remove hard-coded empty graph and use the graph fetched from fcos-graph-builder
-    let cached_graph = graph::Graph::default();
+    let cached_graph = utils::fetch_graph_from_gb(stream.clone(), basearch.clone()).await?;
 
-    let arch_graph = policy::pick_basearch(cached_graph, basearch)?;
-    let throttled_graph = policy::throttle_rollouts(arch_graph, wariness);
+    let throttled_graph = policy::throttle_rollouts(cached_graph, wariness);
     let final_graph = policy::filter_deadends(throttled_graph);
 
     let json =

--- a/fcos-policy-engine/src/utils.rs
+++ b/fcos-policy-engine/src/utils.rs
@@ -1,0 +1,51 @@
+use actix::prelude::*;
+use commons::graph;
+use failure::{bail, Error, Fallible, SyncFailure};
+use reqwest::Method;
+use std::time::Duration;
+
+/// Default timeout for HTTP requests (30 minutes).
+const DEFAULT_HTTP_REQ_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+/// Default address of fcos-graph-builder, which is the same as fcos-policy-builer
+const DEFAULT_GB_ADDR: &str = "http://127.0.0.1:5050/v1/graph";
+
+/// Return a request builder with base URL and parameters set.
+fn new_request(method: reqwest::Method, url: reqwest::Url) -> Fallible<reqwest::RequestBuilder> {
+    let client = reqwest::ClientBuilder::new()
+        .timeout(DEFAULT_HTTP_REQ_TIMEOUT)
+        .build()?;
+    let builder = client.request(method, url);
+    Ok(builder)
+}
+
+/// Fetch the graph from the fcos-graph-builder instance with the query specified.
+pub(crate) fn fetch_graph_from_gb(
+    stream: String,
+    basearch: String,
+) -> impl Future<Output = Result<graph::Graph, Error>> {
+    async move {
+        if stream.trim().is_empty() {
+            bail!("unexpected missing stream");
+        }
+        if basearch.trim().is_empty() {
+            bail!("unexpected missing basearch");
+        }
+        let query = crate::GraphQuery {
+            stream: Some(stream),
+            basearch: Some(basearch),
+            rollout_wariness: None,
+            node_uuid: None,
+        };
+        // Cannot use `?` directly here otherwise will produce the error:
+        //   the trait `std::marker::Sync` is not implemented for `(dyn std::error::Error + std::marker::Send + 'static)`
+        // Reference: https://github.com/rust-lang-nursery/failure/issues/284
+        let query_str = serde_qs::to_string(&query).map_err(SyncFailure::new)?;
+        let mut target = reqwest::Url::parse(DEFAULT_GB_ADDR)?;
+        target.set_query(Some(&query_str));
+        let req = new_request(Method::GET, target)?;
+        let resp = req.send().await?;
+        let content = resp.error_for_status()?;
+        let json = content.json::<graph::Graph>().await?;
+        Ok(json)
+    }
+}


### PR DESCRIPTION
Removes previous empty dummy graph returned by `fcos-policy-engine` and fetches the graph from `fcos-graph-builder` instance, which is running under the same pod as `fcos-policy-engine`.

Also changes ports used by `fcos-*` such that they don't conflict with `dumnati` ports.

Related to: https://github.com/coreos/fedora-coreos-cincinnati/issues/3
Signed-off-by: Allen Bai <abai@redhat.com>