### PR TITLE
dockerfile: put all binaries in PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This service provides an implementation of the [Cincinnati protocol][cincinnati]
 
 This workspace can be built with `cargo build` and contains the following binaries:
 
- * `dumnati`: initial development stub
+ * `fcos-graph-builder`: a service which builds and caches the raw update graph
+ * `fcos-policy-engine`: a web service which handles requests from agents
+ * `dumnati`: initial development stub (legacy)
 
 [cincinnati]: https://github.com/openshift/cincinnati
 [zincati]: https://github.com/coreos/zincati

--- a/dist/fedora-infra/Dockerfile
+++ b/dist/fedora-infra/Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /src
 
 # build: release binary
 RUN cargo build --release && \
+  mv /src/target/release/fcos-graph-builder /usr/local/bin/fcos-graph-builder && \
+  mv /src/target/release/fcos-policy-engine /usr/local/bin/fcos-policy-engine && \
   mv /src/target/release/dumnati /usr/local/bin/dumnati
 
 # build: cleanup


### PR DESCRIPTION
This moves the new graph-builder and policy-engine binaries to
/usr/local/bin/ too.