### PR TITLE
fcos-*: use separate ports for fcos-* modules

### DIFF
--- a/fcos-graph-builder/src/main.rs
+++ b/fcos-graph-builder/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> Fallible<()> {
             .data(gb_service.clone())
             .route("/v1/graph", web::get().to(gb_serve_graph))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 8080))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 5050))?
     .run();
 
     // Graph-builder status service.
@@ -83,7 +83,7 @@ fn main() -> Fallible<()> {
             .data(gb_status.clone())
             .route("/metrics", web::get().to(metrics::serve_metrics))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 9080))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 6060))?
     .run();
 
     sys.run()?;

--- a/fcos-policy-engine/src/main.rs
+++ b/fcos-policy-engine/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> Fallible<()> {
             .data(pe_service.clone())
             .route("/v1/graph", web::get().to(pe_serve_graph))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 8081))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 5051))?
     .run();
 
     // Policy-engine status service.
@@ -71,7 +71,7 @@ fn main() -> Fallible<()> {
             .data(pe_status.clone())
             .route("/metrics", web::get().to(metrics::serve_metrics))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 9081))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 6061))?
     .run();
 
     sys.run()?;


### PR DESCRIPTION
This separates ports used by fcos-* modules from ports used by dumnati.
fcos-graph-builder uses: 5050, 6060
fcos-policy-engine uses: 5051, 6061
dumnati uses: 8080, 8081, 9080, 9081

Signed-off-by: Allen Bai <abai@redhat.com>