### PR TITLE
commons: add CORS helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,7 @@ dependencies = [
 name = "commons"
 version = "0.1.0"
 dependencies = [
+ "actix-cors 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/commons/Cargo.toml
+++ b/commons/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+actix-cors = "^0.2"
 actix-web = "^2.0.0"
 chrono = "^0.4.7"
 failure = "^0.1.1"

--- a/commons/src/lib.rs
+++ b/commons/src/lib.rs
@@ -2,3 +2,4 @@ pub mod graph;
 pub mod metadata;
 pub mod metrics;
 pub mod policy;
+pub mod web;

--- a/commons/src/web.rs
+++ b/commons/src/web.rs
@@ -1,0 +1,10 @@
+use actix_cors::CorsFactory;
+
+/// Provide a CORS middleware allowing given origins.
+pub fn build_cors_middleware(allowed_origins: &[&str]) -> CorsFactory {
+    let mut builder = actix_cors::Cors::new();
+    for origin in allowed_origins {
+        builder = builder.allowed_origin(origin);
+    }
+    builder.finish()
+}

--- a/fcos-graph-builder/src/main.rs
+++ b/fcos-graph-builder/src/main.rs
@@ -54,6 +54,7 @@ fn main() -> Fallible<()> {
     let sys = actix::System::new("fcos_cincinnati_gb");
 
     // TODO(lucab): figure out all configuration params.
+    let allowed_origins = vec!["https://builds.coreos.fedoraproject.org"];
     let streams_cfg = maplit::btreeset!["next", "stable", "testing"];
     let mut scrapers = HashMap::with_capacity(streams_cfg.len());
     for stream in streams_cfg {
@@ -70,6 +71,7 @@ fn main() -> Fallible<()> {
     let gb_service = service_state.clone();
     actix_web::HttpServer::new(move || {
         App::new()
+            .wrap(commons::web::build_cors_middleware(&allowed_origins))
             .data(gb_service.clone())
             .route("/v1/graph", web::get().to(gb_serve_graph))
     })

--- a/fcos-policy-engine/src/main.rs
+++ b/fcos-policy-engine/src/main.rs
@@ -46,6 +46,7 @@ fn main() -> Fallible<()> {
 
     let sys = actix::System::new("fcos_cincinnati_pe");
 
+    let allowed_origins = vec!["https://builds.coreos.fedoraproject.org"];
     let node_population = Arc::new(cbloom::Filter::new(10 * 1024 * 1024, 1_000_000));
     let service_state = AppState {
         population: Arc::clone(&node_population),
@@ -58,6 +59,7 @@ fn main() -> Fallible<()> {
     let pe_service = service_state.clone();
     actix_web::HttpServer::new(move || {
         App::new()
+            .wrap(commons::web::build_cors_middleware(&allowed_origins))
             .data(pe_service.clone())
             .route("/v1/graph", web::get().to(pe_serve_graph))
     })


### PR DESCRIPTION
This adds a common helper for CORS logic and wires it into
graph-builder and policy-engine.

Ref: https://github.com/coreos/fedora-coreos-cincinnati/pull/18