### PR TITLE
graph-builder: move to final default port

### DIFF
--- a/dumnati/src/main.rs
+++ b/dumnati/src/main.rs
@@ -101,7 +101,7 @@ fn main() -> Fallible<()> {
             .data(gb_service.clone())
             .route("/v1/graph", web::get().to(gb_serve_graph))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 8080))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 5050))?
     .run();
 
     // Graph-builder status service.
@@ -111,7 +111,7 @@ fn main() -> Fallible<()> {
             .data(gb_status.clone())
             .route("/metrics", web::get().to(metrics::serve_metrics))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 9080))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 6060))?
     .run();
 
     // Policy-engine service.

--- a/fcos-graph-builder/src/main.rs
+++ b/fcos-graph-builder/src/main.rs
@@ -75,7 +75,7 @@ fn main() -> Fallible<()> {
             .data(gb_service.clone())
             .route("/v1/graph", web::get().to(gb_serve_graph))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 5050))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 8080))?
     .run();
 
     // Graph-builder status service.
@@ -85,7 +85,7 @@ fn main() -> Fallible<()> {
             .data(gb_status.clone())
             .route("/metrics", web::get().to(metrics::serve_metrics))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 6060))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 9080))?
     .run();
 
     sys.run()?;

--- a/fcos-policy-engine/src/utils.rs
+++ b/fcos-policy-engine/src/utils.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 
 /// Default timeout for HTTP requests (30 minutes).
 const DEFAULT_HTTP_REQ_TIMEOUT: Duration = Duration::from_secs(30 * 60);
-/// Default address of fcos-graph-builder, which is the same as fcos-policy-builer
-const DEFAULT_GB_ADDR: &str = "http://127.0.0.1:5050/v1/graph";
+/// Default address of fcos-graph-builder, which is running in the same pod.
+const DEFAULT_GB_ADDR: &str = "http://127.0.0.1:8080/v1/graph";
 
 /// Return a request builder with base URL and parameters set.
 fn new_request(method: reqwest::Method, url: reqwest::Url) -> Fallible<reqwest::RequestBuilder> {


### PR DESCRIPTION
This finalizes graph-builder swap, moving the new binary into
the original default port.