### PR TITLE
policy-engine: move to final default port

### DIFF
--- a/dumnati/src/main.rs
+++ b/dumnati/src/main.rs
@@ -122,7 +122,7 @@ fn main() -> Fallible<()> {
             .data(pe_service.clone())
             .route("/v1/graph", web::get().to(pe_serve_graph))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 8081))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 5051))?
     .run();
 
     // Policy-engine status service.
@@ -132,7 +132,7 @@ fn main() -> Fallible<()> {
             .data(pe_status.clone())
             .route("/metrics", web::get().to(metrics::serve_metrics))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 9081))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 6061))?
     .run();
 
     sys.run()?;

--- a/fcos-policy-engine/src/main.rs
+++ b/fcos-policy-engine/src/main.rs
@@ -78,7 +78,7 @@ fn main() -> Fallible<()> {
             .data(pe_service.clone())
             .route("/v1/graph", web::get().to(pe_serve_graph))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 5051))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 8081))?
     .run();
 
     // Policy-engine status service.
@@ -88,7 +88,7 @@ fn main() -> Fallible<()> {
             .data(pe_status.clone())
             .route("/metrics", web::get().to(metrics::serve_metrics))
     })
-    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 6061))?
+    .bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 9081))?
     .run();
 
     sys.run()?;


### PR DESCRIPTION
This finalizes policy-engine swap, moving the new binary into
the original default port.