### PR TITLE
main: print timestamp for log entries

### DIFF
--- a/fcos-graph-builder/src/main.rs
+++ b/fcos-graph-builder/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Fallible<()> {
 
     // Setup logging.
     env_logger::Builder::from_default_env()
-        .format_timestamp(None)
+        .format_timestamp_secs()
         .format_module_path(false)
         .filter(Some(APP_LOG_TARGET), cli_opts.loglevel())
         .try_init()

--- a/fcos-policy-engine/src/main.rs
+++ b/fcos-policy-engine/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> Fallible<()> {
 
     // Setup logging.
     env_logger::Builder::from_default_env()
-        .format_timestamp(None)
+        .format_timestamp_secs()
         .format_module_path(false)
         .filter(Some(APP_LOG_TARGET), cli_opts.loglevel())
         .try_init()


### PR DESCRIPTION
This enables timestamping when printing log entries, as it is
otherwise difficult to locate recent events on a log stream.