### PR TITLE
commons/web: make CORS origin allowlist optional

### DIFF
--- a/commons/src/web.rs
+++ b/commons/src/web.rs
@@ -1,10 +1,20 @@
 use actix_cors::CorsFactory;
 
-/// Provide a CORS middleware allowing given origins.
-pub fn build_cors_middleware(allowed_origins: &[impl AsRef<str>]) -> CorsFactory {
+/// Build a CORS middleware.
+///
+/// By default, this allows all CORS requests from all origins.
+/// If an allowlist is provided, only those origins are allowed instead.
+pub fn build_cors_middleware(origin_allowlist: &Option<Vec<String>>) -> CorsFactory {
     let mut builder = actix_cors::Cors::new();
-    for origin in allowed_origins {
-        builder = builder.allowed_origin(origin.as_ref());
-    }
+    match origin_allowlist {
+        Some(allowed) => {
+            for origin in allowed {
+                builder = builder.allowed_origin(origin.as_ref());
+            }
+        }
+        None => {
+            builder = builder.send_wildcard();
+        }
+    };
     builder.finish()
 }

--- a/fcos-graph-builder/src/main.rs
+++ b/fcos-graph-builder/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> Fallible<()> {
     actix_web::HttpServer::new(move || {
         App::new()
             .wrap(commons::web::build_cors_middleware(
-                &service_settings.allowed_origins,
+                &service_settings.origin_allowlist,
             ))
             .data(gb_service.clone())
             .route("/v1/graph", web::get().to(gb_serve_graph))

--- a/fcos-graph-builder/src/settings.rs
+++ b/fcos-graph-builder/src/settings.rs
@@ -21,15 +21,13 @@ impl GraphBuilderSettings {
 /// Runtime settings for the main service (graph endpoint) server.
 #[derive(Clone, Debug)]
 pub struct ServiceSettings {
-    pub(crate) allowed_origins: Vec<String>,
+    pub(crate) origin_allowlist: Option<Vec<String>>,
     pub(crate) ip_addr: IpAddr,
     pub(crate) port: u16,
     pub(crate) streams: BTreeSet<String>,
 }
 
 impl ServiceSettings {
-    /// Default allowed CORS origin.
-    const DEFAULT_CORS_URL: &'static str = "https://builds.coreos.fedoraproject.org";
     /// Default IP address for graph-builder main service.
     const DEFAULT_GB_SERVICE_ADDR: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
     /// Default TCP port for graph-builder main service.
@@ -45,7 +43,7 @@ impl ServiceSettings {
 impl Default for ServiceSettings {
     fn default() -> Self {
         Self {
-            allowed_origins: vec![Self::DEFAULT_CORS_URL.to_string()],
+            origin_allowlist: None,
             ip_addr: Self::DEFAULT_GB_SERVICE_ADDR.into(),
             port: Self::DEFAULT_GB_SERVICE_PORT,
             streams: Self::DEFAULT_STREAMS

--- a/fcos-policy-engine/src/main.rs
+++ b/fcos-policy-engine/src/main.rs
@@ -92,7 +92,7 @@ fn main() -> Fallible<()> {
     actix_web::HttpServer::new(move || {
         App::new()
             .wrap(commons::web::build_cors_middleware(
-                &service_settings.allowed_origins,
+                &service_settings.origin_allowlist,
             ))
             .data(service_state.clone())
             .route("/v1/graph", web::get().to(pe_serve_graph))

--- a/fcos-policy-engine/src/settings.rs
+++ b/fcos-policy-engine/src/settings.rs
@@ -21,7 +21,7 @@ impl PolicyEngineSettings {
 /// Runtime settings for the main service (graph endpoint) server.
 #[derive(Clone, Debug)]
 pub struct ServiceSettings {
-    pub(crate) allowed_origins: Vec<String>,
+    pub(crate) origin_allowlist: Option<Vec<String>>,
     pub(crate) bloom_max_population: usize,
     pub(crate) bloom_size: usize,
     pub(crate) ip_addr: IpAddr,
@@ -35,8 +35,6 @@ impl ServiceSettings {
     const DEFAULT_BLOOM_MAX_MEMBERS: usize = 1_000_000;
     /// Default size of the Bloom filter for unique IDs tracking.
     const DEFAULT_BLOOM_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
-    /// Default allowed CORS origin.
-    const DEFAULT_CORS_URL: &'static str = "https://builds.coreos.fedoraproject.org";
     /// Default IP address for policy-engine main service.
     const DEFAULT_PE_SERVICE_ADDR: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
     /// Default TCP port for policy-engine main service.
@@ -55,7 +53,7 @@ impl ServiceSettings {
 impl Default for ServiceSettings {
     fn default() -> Self {
         Self {
-            allowed_origins: vec![Self::DEFAULT_CORS_URL.to_string()],
+            origin_allowlist: None,
             bloom_max_population: Self::DEFAULT_BLOOM_MAX_MEMBERS,
             bloom_size: Self::DEFAULT_BLOOM_SIZE,
             ip_addr: Self::DEFAULT_PE_SERVICE_ADDR.into(),


### PR DESCRIPTION
This tweaks CORS middleware in order to make the origin allowlist
optional. If no allowlist is provided, all origins are accepted.