### PR TITLE
workflows: bump toolchain; restrict repository access

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-fedora-infra:
     name: "Build container image (fedora-infra)"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,14 @@
 ---
 name: Rust
+
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.44.0
+  ACTION_MSRV_TOOLCHAIN: 1.49.0
   # Pinned toolchain for linting
   ACTION_LINTS_TOOLCHAIN: 1.53.0
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Fedora CoreOS updates backend
 
 ![Checks status](https://img.shields.io/github/checks-status/coreos/fedora-coreos-cincinnati/main)
-![minimum rust 1.39](https://img.shields.io/badge/rust-1.39%2B-orange.svg)
+![minimum rust 1.49](https://img.shields.io/badge/rust-1.49%2B-orange.svg)
 
 This repository contains the logic for Fedora CoreOS auto-updates backend.
 


### PR DESCRIPTION
OCP 4.9 has Rust 1.49.