### PR TITLE
Revert "dist/Dockerfile: bump base image to Fedora 34"

### DIFF
--- a/dist/fedora-infra/Dockerfile
+++ b/dist/fedora-infra/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:34
+FROM registry.fedoraproject.org/fedora:33
 
 # build: system utilities and libraries
 RUN dnf -y install g++ openssl-devel


### PR DESCRIPTION
This reverts commit c81254e4080f3187c5b7abf24ea92e84672725f4.

Ref: https://pagure.io/fedora-infrastructure/issue/10111#comment-746286