### PR TITLE
graph-builder: add metrics around cache requests

### DIFF
--- a/fcos-graph-builder/src/main.rs
+++ b/fcos-graph-builder/src/main.rs
@@ -22,6 +22,11 @@ use structopt::StructOpt;
 static APP_LOG_TARGET: &str = "fcos_graph_builder";
 
 lazy_static::lazy_static! {
+    static ref CACHED_GRAPH_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "fcos_cincinnati_gb_cache_graph_requests_total",
+        "Total number of requests for a cached graph",
+        &["basearch", "stream"]
+    ).unwrap();
     static ref GRAPH_FINAL_EDGES: IntGaugeVec = register_int_gauge_vec!(
         "fcos_cincinnati_gb_scraper_graph_final_edges",
         "Number of edges in the cached graph, after processing",

--- a/fcos-graph-builder/src/scraper.rs
+++ b/fcos-graph-builder/src/scraper.rs
@@ -165,6 +165,7 @@ impl Handler<GetCachedGraph> for Scraper {
 
     fn handle(&mut self, msg: GetCachedGraph, _ctx: &mut Self::Context) -> Self::Result {
         use failure::format_err;
+
         if msg.scope.basearch != self.scope.basearch {
             return Box::new(actix::fut::err(format_err!(
                 "unexpected basearch '{}'",
@@ -177,6 +178,10 @@ impl Handler<GetCachedGraph> for Scraper {
                 msg.scope.stream
             )));
         }
+
+        crate::CACHED_GRAPH_REQUESTS
+            .with_label_values(&[&self.scope.basearch, &self.scope.stream])
+            .inc();
         Box::new(actix::fut::ok(self.graph.clone()))
     }
 }


### PR DESCRIPTION
This enhances graph-builder metrics, allowing to inspect access
patterns to cached graphs.