### PR TITLE
graph-builder: add scopes for all aarch64 streams

### DIFF
--- a/commons/src/graph.rs
+++ b/commons/src/graph.rs
@@ -212,7 +212,7 @@ impl Graph {
 }
 
 /// The scope of a cached graph, i.e. the specific stream and basearch that it is valid for.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GraphScope {
     pub basearch: String,
     pub stream: String,

--- a/fcos-graph-builder/src/main.rs
+++ b/fcos-graph-builder/src/main.rs
@@ -77,15 +77,10 @@ fn main() -> Fallible<()> {
         (settings.service, settings.status)
     };
 
-    let mut scrapers = HashMap::with_capacity(service_settings.streams.len());
-    for stream in &service_settings.streams {
-        let scope = graph::GraphScope {
-            // TODO(lucab): get this through settings, and add 'aarch64'.
-            basearch: "x86_64".to_string(),
-            stream: stream.clone(),
-        };
+    let mut scrapers = HashMap::with_capacity(service_settings.scopes.len());
+    for scope in &service_settings.scopes {
         let addr = scraper::Scraper::new(scope.clone())?.start();
-        scrapers.insert(scope, addr);
+        scrapers.insert(scope.clone(), addr);
     }
 
     // TODO(lucab): get allowed scopes from config file.

--- a/fcos-graph-builder/src/settings.rs
+++ b/fcos-graph-builder/src/settings.rs
@@ -1,4 +1,5 @@
-use super::config::FileConfig;
+use crate::config::FileConfig;
+use commons::graph::GraphScope;
 use failure::Fallible;
 use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -24,7 +25,7 @@ pub struct ServiceSettings {
     pub(crate) origin_allowlist: Option<Vec<String>>,
     pub(crate) ip_addr: IpAddr,
     pub(crate) port: u16,
-    pub(crate) streams: BTreeSet<String>,
+    pub(crate) scopes: BTreeSet<GraphScope>,
 }
 
 impl ServiceSettings {
@@ -32,8 +33,13 @@ impl ServiceSettings {
     const DEFAULT_GB_SERVICE_ADDR: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
     /// Default TCP port for graph-builder main service.
     const DEFAULT_GB_SERVICE_PORT: u16 = 8080;
-    /// Default streams to process.
-    const DEFAULT_STREAMS: [&'static str; 3] = ["next", "stable", "testing"];
+    /// Default scopes (basearch plus stream) to process.
+    const DEFAULT_SCOPES: [(&'static str, &'static str); 3] = [
+        // TODO(lucab): add 'aarch64' streams.
+        ("x86_64", "next"),
+        ("x86_64", "stable"),
+        ("x86_64", "testing"),
+    ];
 
     pub fn socket_addr(&self) -> SocketAddr {
         SocketAddr::new(self.ip_addr, self.port)
@@ -46,9 +52,12 @@ impl Default for ServiceSettings {
             origin_allowlist: None,
             ip_addr: Self::DEFAULT_GB_SERVICE_ADDR.into(),
             port: Self::DEFAULT_GB_SERVICE_PORT,
-            streams: Self::DEFAULT_STREAMS
+            scopes: Self::DEFAULT_SCOPES
                 .iter()
-                .map(ToString::to_string)
+                .map(|(basearch, stream)| GraphScope {
+                    basearch: basearch.to_string(),
+                    stream: stream.to_string(),
+                })
                 .collect(),
         }
     }

--- a/fcos-graph-builder/src/settings.rs
+++ b/fcos-graph-builder/src/settings.rs
@@ -34,8 +34,10 @@ impl ServiceSettings {
     /// Default TCP port for graph-builder main service.
     const DEFAULT_GB_SERVICE_PORT: u16 = 8080;
     /// Default scopes (basearch plus stream) to process.
-    const DEFAULT_SCOPES: [(&'static str, &'static str); 3] = [
-        // TODO(lucab): add 'aarch64' streams.
+    const DEFAULT_SCOPES: [(&'static str, &'static str); 6] = [
+        ("aarch64", "next"),
+        ("aarch64", "stable"),
+        ("aarch64", "testing"),
         ("x86_64", "next"),
         ("x86_64", "stable"),
         ("x86_64", "testing"),


### PR DESCRIPTION
This adds graph-builder support for processing and caching 'aarch64' graphs.

Closes: https://github.com/coreos/fedora-coreos-cincinnati/issues/51