### PR TITLE
graph-builder: cache graphs as already serialized data

### DIFF
--- a/commons/src/graph.rs
+++ b/commons/src/graph.rs
@@ -1,4 +1,4 @@
-use crate::metadata;
+use crate::{metadata, policy};
 use failure::Fallible;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -77,9 +77,12 @@ impl Graph {
 
         // Compute the update graph.
         let edges = Self::compute_edges(&nodes)?;
-
         let graph = Graph { nodes, edges };
-        Ok(graph)
+
+        // Filter deadends.
+        let final_graph = policy::filter_deadends(graph);
+
+        Ok(final_graph)
     }
 
     /// Compute edges based on graph metadata.


### PR DESCRIPTION
This tweaks the graph-builder scraping logic to directly cache the
already serialized JSON data. As the caches are already fully split
according to basearch/stream scope, there is no need to further
process graph data on each request.