### PR TITLE
dist/Dockerfile: bump base image to Fedora 35

### DIFF
--- a/dist/fedora-infra/Dockerfile
+++ b/dist/fedora-infra/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:34
+FROM registry.fedoraproject.org/fedora:35
 
 # build: system utilities and libraries
 RUN dnf -y install g++ openssl-devel


### PR DESCRIPTION
This updates the container base image to Fedora 35.