### PR TITLE
graph-builder: add scopes for s390x

### DIFF
--- a/fcos-graph-builder/src/settings.rs
+++ b/fcos-graph-builder/src/settings.rs
@@ -34,10 +34,12 @@ impl ServiceSettings {
     /// Default TCP port for graph-builder main service.
     const DEFAULT_GB_SERVICE_PORT: u16 = 8080;
     /// Default scopes (basearch plus stream) to process.
-    const DEFAULT_SCOPES: [(&'static str, &'static str); 6] = [
+    const DEFAULT_SCOPES: [(&'static str, &'static str); 8] = [
         ("aarch64", "next"),
         ("aarch64", "stable"),
         ("aarch64", "testing"),
+        ("s390x", "next"),
+        ("s390x", "testing"),
         ("x86_64", "next"),
         ("x86_64", "stable"),
         ("x86_64", "testing"),


### PR DESCRIPTION
FCOS is now publishing s390x streams.