### PR TITLE
graph-builder: add 'stable' stream for s390x

### DIFF
--- a/fcos-graph-builder/src/settings.rs
+++ b/fcos-graph-builder/src/settings.rs
@@ -34,11 +34,12 @@ impl ServiceSettings {
     /// Default TCP port for graph-builder main service.
     const DEFAULT_GB_SERVICE_PORT: u16 = 8080;
     /// Default scopes (basearch plus stream) to process.
-    const DEFAULT_SCOPES: [(&'static str, &'static str); 8] = [
+    const DEFAULT_SCOPES: [(&'static str, &'static str); 9] = [
         ("aarch64", "next"),
         ("aarch64", "stable"),
         ("aarch64", "testing"),
         ("s390x", "next"),
+        ("s390x", "stable"),
         ("s390x", "testing"),
         ("x86_64", "next"),
         ("x86_64", "stable"),


### PR DESCRIPTION
This adds the "stable" stream for s390x, which is about to go live
on FCOS.