### PR TITLE
Dockerfile: use quay.io as source for Fedora base image

### DIFF
--- a/dist/fedora-infra/Dockerfile
+++ b/dist/fedora-infra/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:42
+FROM quay.io/fedora/fedora:42
 
 # build: system utilities and libraries
 RUN dnf -y install g++ openssl-devel


### PR DESCRIPTION
Switch the builder stage from `registry.fedoraproject.org` to `quay.io/fedora/fedora:42` to align with common usage in container build workflows.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1851