### PR TITLE
scraper: support releases without ostree commits

### DIFF
--- a/commons/src/graph.rs
+++ b/commons/src/graph.rs
@@ -56,15 +56,26 @@ impl Graph {
                         return None;
                     }
                 } else {
-                    for commit in entry.commits {
-                        if commit.architecture != scope.basearch || commit.checksum.is_empty() {
-                            continue;
+                    match entry.commits {
+                        Some(commits) if !commits.is_empty() => {
+                            for commit in commits {
+                                if commit.architecture != scope.basearch
+                                    || commit.checksum.is_empty()
+                                {
+                                    continue;
+                                }
+                                has_basearch = true;
+                                current.payload = commit.checksum;
+                                current
+                                    .metadata
+                                    .insert(metadata::SCHEME.to_string(), "checksum".to_string());
+                            }
                         }
-                        has_basearch = true;
-                        current.payload = commit.checksum;
-                        current
-                            .metadata
-                            .insert(metadata::SCHEME.to_string(), "checksum".to_string());
+                        _ => {
+                            // catch-all arm for both `None` and `Some(empty_vec)`,
+                            // both cases should result in skipping the release.
+                            return None;
+                        }
                     }
                 }
 

--- a/commons/src/metadata.rs
+++ b/commons/src/metadata.rs
@@ -31,7 +31,7 @@ pub struct ReleasesJSON {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Release {
-    pub commits: Vec<ReleaseCommit>,
+    pub commits: Option<Vec<ReleaseCommit>>,
     #[serde(rename = "oci-images")]
     pub oci_images: Option<Vec<ReleaseOciImage>>,
     pub version: String,


### PR DESCRIPTION
As part as [1] we want to have releases with only OCI images shipped. Make the commits optional so cincinnati will still build a graph if the ostree commit is missing.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1895